### PR TITLE
Removed add_clampedi for now.

### DIFF
--- a/doc_classes/Omake.xml
+++ b/doc_classes/Omake.xml
@@ -9,17 +9,6 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="add_clampedi" qualifiers="static">
-			<return type="int" />
-			<param index="0" name="a" type="int" />
-			<param index="1" name="b" type="int" />
-			<param index="2" name="min" type="int" default="-9223372036854775808" />
-			<param index="3" name="max" type="int" default="9223372036854775807" />
-			<description>
-				Returns a + b, but will return max instead of overflow, or min instead of underflow.
-				By default min is INT64_MIN and max is INT64_MAX.
-			</description>
-		</method>
 		<method name="find_all" qualifiers="static">
 			<return type="PackedNodeArray" />
 			<param index="0" name="node" type="Node" />
@@ -98,12 +87,4 @@
 			</description>
 		</method>
 	</methods>
-	<constants>
-		<constant name="INT64_MIN" value="-9223372036854775808">
-			Min signed 64 bit int value.
-		</constant>
-		<constant name="INT64_MAX" value="9223372036854775807">
-			Max signed 64 bit int value.
-		</constant>
-	</constants>
 </class>

--- a/omake.cpp
+++ b/omake.cpp
@@ -36,9 +36,6 @@
 #include "omake_packed_node_array.h"
 #include <cstdint>
 
-const int64_t Omake::_INT64_MIN = INT64_MIN;
-const int64_t Omake::_INT64_MAX = INT64_MAX;
-
 Omake::Omake() {
 	//print_line("Omake created");
 }
@@ -49,20 +46,6 @@ Omake::~Omake() {
 
 uint64_t Omake::get_ticks_nsec() {
 	return omake_get_ticks_nsec();
-}
-
-int64_t Omake::add_clampedi(int64_t a, int64_t b, int64_t min, int64_t max) {
-	// Will overflow so just return max
-	if (b > 0 && a > max - b) {
-		return max;
-	}
-
-	// Will underflow so just return min
-	if (b < 0 && a < min - b) {
-		return min;
-	}
-
-	return CLAMP(a + b, min, max);
 }
 
 Ref<PackedNodeArray> Omake::get_children(const Node *p_node, const bool p_include_internal) {
@@ -106,11 +89,7 @@ PackedStringArray Omake::get_groups(const Node *p_node) {
 }
 
 void Omake::_bind_methods() {
-	ClassDB::bind_integer_constant("Omake", "", "INT64_MIN", Omake::_INT64_MIN);
-	ClassDB::bind_integer_constant("Omake", "", "INT64_MAX", Omake::_INT64_MAX);
-
 	ClassDB::bind_static_method("Omake", D_METHOD("get_ticks_nsec"), &Omake::get_ticks_nsec);
-	ClassDB::bind_static_method("Omake", D_METHOD("add_clampedi", "a", "b", "min", "max"), &Omake::add_clampedi, DEFVAL(Omake::_INT64_MIN), DEFVAL(Omake::_INT64_MAX));
 
 	ClassDB::bind_static_method("Omake", D_METHOD("get_children", "node", "include_internal"), &Omake::get_children, DEFVAL(true));
 	ClassDB::bind_static_method("Omake", D_METHOD("get_children_by_name", "node", "node_name"), &Omake::get_children_by_name);

--- a/omake.h
+++ b/omake.h
@@ -40,14 +40,10 @@ protected:
 	static void _bind_methods();
 
 public:
-	static const int64_t _INT64_MIN;
-	static const int64_t _INT64_MAX;
-
 	Omake();
 	~Omake();
 
 	static uint64_t get_ticks_nsec();
-	static int64_t add_clampedi(int64_t a, int64_t b, int64_t min = _INT64_MIN, int64_t max = _INT64_MAX);
 
 	static Ref<PackedNodeArray> get_children(const Node *p_node, const bool p_include_internal = true);
 	static Ref<PackedNodeArray> get_children_by_name(const Node *p_node, const StringName p_node_name);

--- a/tests/test_omake.h
+++ b/tests/test_omake.h
@@ -34,10 +34,6 @@
 
 namespace TestOmakeMisc {
 
-TEST_CASE("[Omake] test_consts") {
-	CHECK(Omake::_INT64_MIN == INT64_MIN);
-	CHECK(Omake::_INT64_MAX == INT64_MAX);
-}
 
 TEST_CASE("[Omake] test_get_ticks_nsec") {
 	uint64_t ticks_a = Omake::get_ticks_nsec();
@@ -45,17 +41,6 @@ TEST_CASE("[Omake] test_get_ticks_nsec") {
 	CHECK(ticks_a > 0);
 	CHECK(ticks_b > 0);
 	CHECK(ticks_a < ticks_b);
-}
-
-TEST_CASE("[Omake] add_clampedi") {
-	CHECK(6 == Omake::add_clampedi(1, 5, 0, 100)); // Normal add
-	CHECK(-4 == Omake::add_clampedi(1, -5, -100, 100)); // Normal add
-	CHECK(0 == Omake::add_clampedi(6, -900, 0, 100)); // Clamp Underflow
-	CHECK(100 == Omake::add_clampedi(6, 900, 0, 100)); // Clamp Overflow
-
-	CHECK(INT64_MAX == Omake::add_clampedi(7, INT64_MAX)); // Clamp Overflow
-	CHECK(INT64_MIN == Omake::add_clampedi(-8, INT64_MIN)); // Clamp Underflow
-	CHECK(0 == Omake::add_clampedi(0, INT64_MIN, 0, INT64_MAX)); // Clamp Underflow
 }
 
 } //namespace TestOmakeMisc


### PR DESCRIPTION
This was giving compile errors on cpp bindings from INT64_MIN and INT64_MAX being too big, despite being correct size.